### PR TITLE
make sorting optional when creating xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ This would produce something like:
 </Document>
 ```
 
-Note that elements and attributes may lose their original ordering, as hashes have an undefined key order.  However, to keep things consistent, they are both alphabetically sorted when serialized.
+Note that elements and attributes may lose their original ordering, as hashes have an undefined key order. However, to keep things consistent, they are both alphabetically sorted when serialized. If you would like to skip this sorting and hope for the best :), pass false as the last parameter `var xml_string = XML.stringify( doc, 'Document', 0, "", "", false );`
 
 If you are composing an XML document which has the document root node preserved (see [preserveDocumentNode](#preserveDocumentNode) above), simply omit the name parameter, and only pass in the object.  Example:
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The simplified API provides basic `XML.parse()` and `XML.stringify()` standalone
 Parse some XML by passing a string to `XML.parse()`:
 
 ```javascript
-var xml_string = '<?xml version="1.0"?><Document>' + 
-	'<Simple>Hello</Simple>' + 
-	'<Node Key="Value">Complex</Node>' + 
+var xml_string = '<?xml version="1.0"?><Document>' +
+	'<Simple>Hello</Simple>' +
+	'<Node Key="Value">Complex</Node>' +
 	'</Document>';
 
 var doc = XML.parse( xml_string );
@@ -84,9 +84,9 @@ You can pass an optional 2nd argument to `parse()`, which can be an object conta
 This optional property, when set to `true`, will cause all XML attributes to be kept separate in their own sub-object called `_Attribs` for each element.  For example, consider this snippet:
 
 ```javascript
-var xml_string = '<?xml version="1.0"?><Document>' + 
-	'<Simple>Hello</Simple>' + 
-	'<Node Key="Value">Complex</Node>' + 
+var xml_string = '<?xml version="1.0"?><Document>' +
+	'<Simple>Hello</Simple>' +
+	'<Node Key="Value">Complex</Node>' +
 	'</Document>';
 
 var doc = XML.parse( xml_string, { preserveAttributes: true } );
@@ -114,9 +114,9 @@ Notice the `Key` attribute of the `<Node>` element is now kept in an `_Attribs` 
 This optional property, when set to `true`, will cause all keys to be lower-cased as the XML is parsed.  This affects both elements and attributes.  Example:
 
 ```javascript
-var xml_string = '<?xml version="1.0"?><Document>' + 
-	'<Simple>Hello</Simple>' + 
-	'<Node Key="Value">Complex</Node>' + 
+var xml_string = '<?xml version="1.0"?><Document>' +
+	'<Simple>Hello</Simple>' +
+	'<Node Key="Value">Complex</Node>' +
 	'</Document>';
 
 var doc = XML.parse( xml_string, { lowerCase: true } );
@@ -142,9 +142,9 @@ Note that the values themselves are not touched -- only the keys are lower-cased
 If you want the outermost root node (also called the document node) preserved when parsing, set the `preserveDocumentNode` property to true when parsing.  Example:
 
 ```js
-var xml_string = '<?xml version="1.0"?><Document>' + 
-	'<Simple>Hello</Simple>' + 
-	'<Node Key="Value">Complex</Node>' + 
+var xml_string = '<?xml version="1.0"?><Document>' +
+	'<Simple>Hello</Simple>' +
+	'<Node Key="Value">Complex</Node>' +
 	'</Document>';
 
 var doc = XML.parse( xml_string, { preserveDocumentNode: true } );
@@ -184,7 +184,7 @@ This would produce something like:
 </Document>
 ```
 
-Note that elements and attributes may lose their original ordering, as hashes have an undefined key order.  However, to keep things consistent, they are both alphabetically sorted when serialized.
+Note that elements and attributes may lose their original ordering, as hashes have an undefined key order.  However, to keep things consistent, they are both alphabetically sorted when serialized. If you would like to skip this sorting and hope for the best :), pass false as the last parameter `var xml_string = XML.stringify( doc, 'Document', 0, "", "", false );`
 
 If you are composing an XML document which has the document root node preserved (see [preserveDocumentNode](#preserveDocumentNode) above), simply omit the name parameter, and only pass in the object.  Example:
 
@@ -222,9 +222,9 @@ After constructing the `XML.Parser` object, and no error was thrown, call `getTr
 The main reason for using this API is that it preserves any PI ([Processing Instruction](https://en.wikipedia.org/wiki/Processing_Instruction)) and DTD ([Document Type Definition](https://en.wikipedia.org/wiki/Document_type_definition)) elements in the source XML file, and they will be serialized into the output.  Example:
 
 ```js
-var xml_string = '<?xml version="1.0" encoding="UTF-8"?><Document>' + 
-	'<Simple>Hello</Simple>' + 
-	'<Node Key="Value">Complex</Node>' + 
+var xml_string = '<?xml version="1.0" encoding="UTF-8"?><Document>' +
+	'<Simple>Hello</Simple>' +
+	'<Node Key="Value">Complex</Node>' +
 	'</Document>';
 
 var parser = null;

--- a/README.md
+++ b/README.md
@@ -184,11 +184,7 @@ This would produce something like:
 </Document>
 ```
 
-<<<<<<< HEAD
-Note that elements and attributes may lose their original ordering, as hashes have an undefined key order.  However, to keep things consistent, they are both alphabetically sorted when serialized. If you would like to skip this sorting and hope for the best :), pass false as the last parameter `var xml_string = XML.stringify( doc, 'Document', 0, "", "", false );`
-=======
 Note that elements and attributes may lose their original ordering, as hashes have an undefined key order. However, to keep things consistent, they are both alphabetically sorted when serialized. If you would like to skip this sorting and hope for the best :), pass false as the last parameter `var xml_string = XML.stringify( doc, 'Document', 0, "", "", false );`
->>>>>>> sort
 
 If you are composing an XML document which has the document root node preserved (see [preserveDocumentNode](#preserveDocumentNode) above), simply omit the name parameter, and only pass in the object.  Example:
 

--- a/xml.js
+++ b/xml.js
@@ -520,7 +520,7 @@ var compose_xml = exports.stringify = function compose_xml(node, name, indent, i
 
 			if (node["_Attribs"]) {
 				has_attribs = 1;
-                              var sorted_keys = (sort) ? hash_keys_to_array(node["_Attribs"]).sort() : hash_keys_to_array(node["_Attribs"]);
+                                var sorted_keys = (sort) ? hash_keys_to_array(node["_Attribs"]).sort() : hash_keys_to_array(node["_Attribs"]);
 				for (var idx = 0, len = sorted_keys.length; idx < len; idx++) {
 					var key = sorted_keys[idx];
 					xml += " " + key + "=\"" + encode_attrib_entities(node["_Attribs"][key]) + "\"";
@@ -538,7 +538,7 @@ var compose_xml = exports.stringify = function compose_xml(node, name, indent, i
 				else {
 					xml += eol;
 					
-                                      var sorted_keys = (sort) ? hash_keys_to_array(node).sort() : hash_keys_to_array(node);					
+                                        var sorted_keys = (sort) ? hash_keys_to_array(node).sort() : hash_keys_to_array(node);					
 					for (var idx = 0, len = sorted_keys.length; idx < len; idx++) {
 						var key = sorted_keys[idx];
 						if ((key != "_Attribs") && key.match(re_valid_tag_name)) {

--- a/xml.js
+++ b/xml.js
@@ -488,7 +488,7 @@ var compose_xml = exports.stringify = function compose_xml(node, name, indent, i
 	// Recurse for child nodes
 	if (typeof(indent_string) == 'undefined') indent_string = "\t";
 	if (typeof(eol) == 'undefined') eol = "\n";
-      if (typeof(sort) == 'undefined') sort = true;
+        if (typeof(sort) == 'undefined') sort = true;
 	var xml = "";
 
 	// If this is the root node, set the indent to 0

--- a/xml.js
+++ b/xml.js
@@ -483,11 +483,12 @@ var decode_entities = exports.decodeEntities = function decode_entities(text) {
 	return text;
 };
 
-var compose_xml = exports.stringify = function compose_xml(node, name, indent, indent_string, eol) {
+var compose_xml = exports.stringify = function compose_xml(node, name, indent, indent_string, eol, sort) {
 	// Compose node into XML including attributes
 	// Recurse for child nodes
 	if (typeof(indent_string) == 'undefined') indent_string = "\t";
 	if (typeof(eol) == 'undefined') eol = "\n";
+       if (typeof(sort) == 'undefined') sort = true;
 	var xml = "";
 	
 	// If this is the root node, set the indent to 0
@@ -519,7 +520,7 @@ var compose_xml = exports.stringify = function compose_xml(node, name, indent, i
 			
 			if (node["_Attribs"]) {
 				has_attribs = 1;
-				var sorted_keys = hash_keys_to_array(node["_Attribs"]).sort();
+                               var sorted_keys = (sort) ? hash_keys_to_array(node["_Attribs"]).sort() : hash_keys_to_array(node["_Attribs"]);
 				for (var idx = 0, len = sorted_keys.length; idx < len; idx++) {
 					var key = sorted_keys[idx];
 					xml += " " + key + "=\"" + encode_attrib_entities(node["_Attribs"][key]) + "\"";
@@ -537,12 +538,12 @@ var compose_xml = exports.stringify = function compose_xml(node, name, indent, i
 				else {
 					xml += eol;
 					
-					var sorted_keys = hash_keys_to_array(node).sort();
+                                       var sorted_keys = (sort) ? hash_keys_to_array(node).sort() : hash_keys_to_array(node);					
 					for (var idx = 0, len = sorted_keys.length; idx < len; idx++) {
 						var key = sorted_keys[idx];					
 						if ((key != "_Attribs") && key.match(re_valid_tag_name)) {
 							// recurse for node, with incremented indent value
-							xml += compose_xml( node[key], key, indent + 1, indent_string, eol );
+							xml += compose_xml( node[key], key, indent + 1, indent_string, eol, sort );
 						} // not _Attribs key
 					} // foreach key
 					
@@ -558,7 +559,7 @@ var compose_xml = exports.stringify = function compose_xml(node, name, indent, i
 			// node is array
 			for (var idx = 0; idx < node.length; idx++) {
 				// recurse for node in array with same indent
-				xml += compose_xml( node[idx], name, indent, indent_string, eol );
+				xml += compose_xml( node[idx], name, indent, indent_string, eol, sort );
 			}
 		} // array of nodes
 	} // complex node


### PR DESCRIPTION
I used your module to create xsl files. In xsl the order of elements can make a difference, that's why I added an extra parameter to skip sorting and hope for the best (knowing that order is not quaranteed ;)